### PR TITLE
fix(nav): fix dropdown for mobile

### DIFF
--- a/app/components/nav.jsx
+++ b/app/components/nav.jsx
@@ -57,7 +57,7 @@ export class Nav extends Component {
         <nav>
           <Link to="/">Pokédex Tracker</Link>
           <div className="dropdown">
-            <a>{session.username} <i className="fa fa-caret-down" /></a>
+            <a href="#">{session.username} <i className="fa fa-caret-down" /></a>
             <ul>
               {user.dexes.map((dex) => <li key={dex.id}><Link to={`/u/${session.username}/${dex.slug}`}><i className="fa fa-th" /> {dex.title}</Link></li>)}
 


### PR DESCRIPTION
¯\_╏ ՞ ︿ ՞ ╏_/¯

fixes https://github.com/pokedextracker/pokedextracker.com/issues/223

quick fix to allow the dropdown to work on mobile. you can't "un"click it to make it go away, but at least it works now! not sure if there's an "actual" fix other than just making a mobile-only version of the dropdown that is based off clicks instead of hover.