### PR TITLE
refactor(pokemon): use pokemon.id instead of pokemon.national_id

### DIFF
--- a/app/actions/pokemon.js
+++ b/app/actions/pokemon.js
@@ -2,16 +2,21 @@ import { Config }       from '../../config';
 import { API }          from '../utils/api';
 import { checkVersion } from './utils';
 
+export const CLEAR_POKEMON       = 'CLEAR_POKEMON';
 export const SET_POKEMON         = 'SET_POKEMON';
 export const SET_CURRENT_POKEMON = 'SET_CURRENT_POKEMON';
 
-export function retrievePokemon (id) {
+export function retrievePokemon (id, query) {
   return (dispatch) => {
     dispatch(checkVersion());
 
-    return API.get(`${Config.API_HOST}/pokemon/${id}`)
+    return API.get(`${Config.API_HOST}/pokemon/${id}`, query)
     .then((pokemon) => dispatch(setPokemon(pokemon)));
   };
+}
+
+export function clearPokemon () {
+  return { type: CLEAR_POKEMON };
 }
 
 export function setCurrentPokemon (pokemon) {

--- a/app/components/box.jsx
+++ b/app/components/box.jsx
@@ -16,7 +16,7 @@ export function Box ({ captures, dex }) {
         <MarkAllButtonComponent captures={captures} />
       </div>
       <div className="box-container">
-        {captures.map((capture) => <PokemonComponent key={capture.pokemon.national_id} capture={capture} />)}
+        {captures.map((capture) => <PokemonComponent key={capture.pokemon.id} capture={capture} />)}
         {empties.map((index) => <PokemonComponent key={index} capture={null} />)}
       </div>
     </div>

--- a/app/components/dex.jsx
+++ b/app/components/dex.jsx
@@ -51,7 +51,7 @@ export class Dex extends Component {
             <ProgressComponent caught={caught} total={total} />
             <RegionComponent mobile />
           </div>
-          {groups.map((group) => <BoxComponent key={group[0].pokemon.national_id} captures={group} />)}
+          {groups.map((group) => <BoxComponent key={group[0].pokemon.id} captures={group} />)}
         </div>
       </div>
     );

--- a/app/components/evolution-family.jsx
+++ b/app/components/evolution-family.jsx
@@ -11,8 +11,8 @@ export function EvolutionFamily ({ dex, family, setCurrentPokemon }) {
   if (family.pokemon.length > 1) {
     column1 = (
       <div className="evolution-pokemon-column">
-        {family.pokemon[1].map((pokemon) => <a key={pokemon.national_id} onClick={() => setCurrentPokemon(pokemon.national_id)}>
-          <i className={iconClass(pokemon.national_id, dex)} />
+        {family.pokemon[1].map((pokemon) => <a key={pokemon.id} onClick={() => setCurrentPokemon(pokemon.id)}>
+          <i className={iconClass(pokemon, dex)} />
         </a>)}
       </div>
     );
@@ -21,8 +21,8 @@ export function EvolutionFamily ({ dex, family, setCurrentPokemon }) {
   if (family.pokemon.length > 2) {
     column2 = (
       <div className="evolution-pokemon-column">
-        {family.pokemon[2].map((pokemon) => <a key={pokemon.national_id} onClick={() => setCurrentPokemon(pokemon.national_id)}>
-          <i className={iconClass(pokemon.national_id, dex)} />
+        {family.pokemon[2].map((pokemon) => <a key={pokemon.id} onClick={() => setCurrentPokemon(pokemon.id)}>
+          <i className={iconClass(pokemon, dex)} />
         </a>)}
       </div>
     );
@@ -31,8 +31,8 @@ export function EvolutionFamily ({ dex, family, setCurrentPokemon }) {
   return (
     <div className="info-evolutions">
       <div className="evolution-pokemon-column">
-        <a onClick={() => setCurrentPokemon(family.pokemon[0][0].national_id)}>
-          <i className={iconClass(family.pokemon[0][0].national_id, dex)} />
+        <a onClick={() => setCurrentPokemon(family.pokemon[0][0].id)}>
+          <i className={iconClass(family.pokemon[0][0], dex)} />
         </a>
         {family.evolutions.length === 0 ? <div>Does not evolve</div> : null}
       </div>

--- a/app/components/info.jsx
+++ b/app/components/info.jsx
@@ -20,10 +20,10 @@ export class Info extends Component {
   }
 
   reset () {
-    const { currentPokemon, pokemon, retrievePokemon } = this.props;
+    const { currentPokemon, dex, pokemon, retrievePokemon } = this.props;
 
     if (!pokemon) {
-      retrievePokemon(currentPokemon);
+      retrievePokemon(currentPokemon, { generation: dex.generation, region: dex.region });
     }
   }
 
@@ -59,7 +59,7 @@ export class Info extends Component {
 
         <div className="info-main">
           <div className="info-header">
-            <i className={iconClass(pokemon.national_id, dex)} />
+            <i className={iconClass(pokemon, dex)} />
             <h1 dangerouslySetInnerHTML={htmlName(pokemon.name)} />
             <h2>#{padding(pokemon.national_id, 3)}</h2>
           </div>
@@ -85,7 +85,7 @@ function mapStateToProps ({ currentDex, currentUser, currentPokemon, pokemon, sh
 
 function mapDispatchToProps (dispatch) {
   return {
-    retrievePokemon: (id) => dispatch(retrievePokemon(id)),
+    retrievePokemon: (id, query) => dispatch(retrievePokemon(id, query)),
     setShowInfo: (show) => dispatch(setShowInfo(show))
   };
 }

--- a/app/components/mark-all-button.jsx
+++ b/app/components/mark-all-button.jsx
@@ -16,7 +16,7 @@ export class MarkAllButton extends Component {
   toggleCaptured = () => {
     const { captures, createCaptures, currentDex, deleteCaptures, dex, region, user } = this.props;
     const deleting = captures.reduce((total, capture) => total + (!regionCheck(capture.pokemon, region) || capture.captured ? 0 : 1), 0) === 0;
-    const pokemon = captures.filter((capture) => regionCheck(capture.pokemon, region) && capture.captured === deleting).map((capture) => capture.pokemon.national_id);
+    const pokemon = captures.filter((capture) => regionCheck(capture.pokemon, region) && capture.captured === deleting).map((capture) => capture.pokemon.id);
     const payload = { dex: dex.id, pokemon };
 
     Promise.resolve()

--- a/app/components/pokemon.jsx
+++ b/app/components/pokemon.jsx
@@ -17,7 +17,7 @@ export class Pokemon extends Component {
     if (regionCheck(capture.pokemon, region)) {
       ReactGA.event({ action: 'show info', category: 'Pokemon', label: capture.pokemon.name });
 
-      setCurrentPokemon(capture.pokemon.national_id);
+      setCurrentPokemon(capture.pokemon.id);
       setShowInfo(true);
     }
   }
@@ -29,7 +29,7 @@ export class Pokemon extends Component {
       return;
     }
 
-    const payload = { dex: dex.id, pokemon: [capture.pokemon.national_id] };
+    const payload = { dex: dex.id, pokemon: [capture.pokemon.id] };
 
     Promise.resolve()
     .then(() => {
@@ -73,11 +73,11 @@ export class Pokemon extends Component {
       <div className={classNames(classes)}>
         <div className="set-captured" onClick={this.toggleCaptured}>
           <h4 dangerouslySetInnerHTML={htmlName(capture.pokemon.name)} />
-          <i className={iconClass(capture.pokemon.national_id, dex)} />
+          <i className={iconClass(capture.pokemon, dex)} />
           <p>#{padding(capture.pokemon.national_id, 3)}</p>
         </div>
         <div className="set-captured-mobile" onClick={this.toggleCaptured}>
-          <i className={iconClass(capture.pokemon.national_id, dex)} />
+          <i className={iconClass(capture.pokemon, dex)} />
           <h4 dangerouslySetInnerHTML={htmlName(capture.pokemon.name)} />
           <p>#{padding(capture.pokemon.national_id, 3)}</p>
         </div>

--- a/app/components/tracker.jsx
+++ b/app/components/tracker.jsx
@@ -11,7 +11,7 @@ import { checkVersion }                           from '../actions/utils';
 import { listCaptures }                           from '../actions/capture';
 import { retrieveDex, setCurrentDex }             from '../actions/dex';
 import { retrieveUser, setUser }                  from '../actions/user';
-import { setCurrentPokemon }                      from '../actions/pokemon';
+import { clearPokemon, setCurrentPokemon }        from '../actions/pokemon';
 import { setRegion, setShowScroll, setShowShare } from '../actions/tracker';
 
 export class Tracker extends Component {
@@ -35,11 +35,25 @@ export class Tracker extends Component {
   }
 
   reset (props) {
-    const { checkVersion, listCaptures, params: { slug, username }, retrieveDex, retrieveUser, setCurrentDex, setCurrentPokemon, setRegion, setShowScroll, setShowShare, setUser } = props || this.props;
+    const {
+      checkVersion,
+      clearPokemon,
+      listCaptures,
+      params: { slug, username },
+      retrieveDex,
+      retrieveUser,
+      setCurrentDex,
+      setCurrentPokemon,
+      setRegion,
+      setShowScroll,
+      setShowShare,
+      setUser
+    } = props || this.props;
 
     this.setState({ ...this.state, loading: true });
 
     checkVersion();
+    clearPokemon();
     setRegion('national');
     setShowScroll(false);
     setShowShare(false);
@@ -52,7 +66,7 @@ export class Tracker extends Component {
     })
     .then((dex) => listCaptures(dex, username))
     .then((captures) => {
-      setCurrentPokemon(captures[0].pokemon.national_id);
+      setCurrentPokemon(captures[0].pokemon.id);
       this.setState({ ...this.state, loading: false });
     })
     .catch(() => this.setState({ ...this.state, loading: false }));
@@ -97,6 +111,7 @@ function mapStateToProps ({ currentDex, currentUser, users }) {
 function mapDispatchToProps (dispatch) {
   return {
     checkVersion: () => dispatch(checkVersion()),
+    clearPokemon: () => dispatch(clearPokemon()),
     listCaptures: (dex, username) => dispatch(listCaptures(dex, username)),
     retrieveDex: (slug, username) => dispatch(retrieveDex(slug, username)),
     retrieveUser: (username) => dispatch(retrieveUser(username)),

--- a/app/reducers/captures.js
+++ b/app/reducers/captures.js
@@ -28,9 +28,9 @@ export function captures (state = {}, action) {
           }
         }
       };
-      const index = newState[action.username].dexesBySlug[action.slug].captures.findIndex((c) => c.pokemon.national_id === action.pokemon[0]);
+      const index = newState[action.username].dexesBySlug[action.slug].captures.findIndex((c) => c.pokemon.id === action.pokemon[0]);
       for (let i = index, count = 0; count < action.pokemon.length; i++) {
-        if (action.pokemon.indexOf(newState[action.username].dexesBySlug[action.slug].captures[i].pokemon.national_id) !== -1) {
+        if (action.pokemon.indexOf(newState[action.username].dexesBySlug[action.slug].captures[i].pokemon.id) !== -1) {
           newState[action.username].dexesBySlug[action.slug].captures[i].captured = action.captured;
           count++;
         }

--- a/app/reducers/pokemon.js
+++ b/app/reducers/pokemon.js
@@ -1,12 +1,14 @@
-import { SET_POKEMON } from '../actions/pokemon';
+import { CLEAR_POKEMON, SET_POKEMON } from '../actions/pokemon';
 
 export function pokemon (state = {}, action) {
   switch (action.type) {
     case SET_POKEMON:
       return {
         ...state,
-        [action.pokemon.national_id]: action.pokemon
+        [action.pokemon.id]: action.pokemon
       };
+    case CLEAR_POKEMON:
+      return {};
     default:
       return state;
   }

--- a/app/utils/pokemon.js
+++ b/app/utils/pokemon.js
@@ -6,13 +6,13 @@ export function htmlName (name) {
   return { __html: name.replace('♀', '<i class="fa fa-venus"></i>').replace('♂', '<i class="fa fa-mars"></i>') };
 }
 
-export function iconClass (id, dex) {
+export function iconClass ({ national_id: nationalId }, dex) {
   const classes = {
     'color-shiny': dex.shiny,
     'form-alola': dex.generation === 7
   };
 
-  return classNames('pkicon', `pkicon-${padding(id, 3)}`, classes);
+  return classNames('pkicon', `pkicon-${padding(nationalId, 3)}`, classes);
 }
 
 export function regionCheck (pokemon, region) {


### PR DESCRIPTION
(:D)┼─┤

this pr shouldnt actually change anything. its just changing to gradually use some of the newer backend stuff so we can make the change to forms.

to test just make sure that everything still works. just check the things pokemon related (i.e. you dont need to check the account/login stuffs)