### PR TITLE
feat(edit): add region to edit dex

### DIFF
--- a/app/components/dex-indicator.jsx
+++ b/app/components/dex-indicator.jsx
@@ -14,6 +14,7 @@ export function DexIndicatorComponent ({ dex }) {
   return (
     <div className="dex-indicator">
       {shiny}
+      <span className="label">{dex.region === 'national' ? 'National' : 'Regional'}</span>
       <span className="label">Gen {dex.generation}</span>
     </div>
   );


### PR DESCRIPTION
(((ლ(͏ ͒ • ꈊ • ͒)ლ)))♡

- adds "region" label next to shiny and generation labels
- adds region to edit dex. "warning" display is based on this logic:

original | editing to | warning
------- | ---------- | ------
Gen 6 | Gen 7 Regional | Any non-Alola Dex capture info will be lost.
Gen 6 | Gen 7 National | No warning needed.
Gen 7 National | Gen 6 | Any Gen 7 capture info will be lost.
Gen 7 Regional | Gen 6 | Any Gen 7 capture info will be lost.
Gen 7 National | Gen 7 Regional | Any non-Alola Dex capture info will be lost.
Gen 7 Regional | Gen 7 National | No warning needed.

