### PR TITLE
[WIP] refactor(slug): use slugify instead of slug

### DIFF
--- a/app/actions/user.js
+++ b/app/actions/user.js
@@ -1,5 +1,5 @@
 import { push } from 'react-router-redux';
-import slug     from 'slug';
+import slugify  from 'slugify';
 
 import { Config }       from '../../config';
 import { API }          from '../utils/api';
@@ -26,7 +26,7 @@ export function createUser (payload) {
     })
     .then(({ token }) => {
       dispatch(setToken(token));
-      dispatch(push(`/u/${username}/${slug(title, { lower: true })}`));
+      dispatch(push(`/u/${username}/${slugify(title, { lower: true })}`));
     });
   };
 }

--- a/app/actions/user.js
+++ b/app/actions/user.js
@@ -1,10 +1,10 @@
 import { push } from 'react-router-redux';
-import slugify  from 'slugify';
 
 import { Config }       from '../../config';
 import { API }          from '../utils/api';
 import { checkVersion } from './utils';
 import { setToken }     from './session';
+import { slug }         from '../utils/formatting';
 
 export const SET_USER         = 'SET_USER';
 export const SET_CURRENT_USER = 'SET_CURRENT_USER';
@@ -26,7 +26,7 @@ export function createUser (payload) {
     })
     .then(({ token }) => {
       dispatch(setToken(token));
-      dispatch(push(`/u/${username}/${slugify(title, { lower: true })}`));
+      dispatch(push(`/u/${username}/${slug(title)}`));
     });
   };
 }

--- a/app/components/dex-create.jsx
+++ b/app/components/dex-create.jsx
@@ -2,11 +2,11 @@ import { Component } from 'react';
 import Modal         from 'react-modal';
 import { connect }   from 'react-redux';
 import { push }      from 'react-router-redux';
-import slugify       from 'slugify';
 
 import { AlertComponent } from './alert';
 import { ReactGA }        from '../utils/analytics';
 import { createDex }      from '../actions/dex';
+import { slug }           from '../utils/formatting';
 
 export class DexCreate extends Component {
 
@@ -73,7 +73,7 @@ export class DexCreate extends Component {
           <form onSubmit={this.onSubmit} className="form-column">
             <AlertComponent message={error} type="error" />
             <div className="form-group">
-              <div className="form-note">/u/{session.username}/{slugify(url || 'Living Dex', { lower: true })}</div>
+              <div className="form-note">/u/{session.username}/{slug(url || 'Living Dex')}</div>
               <label htmlFor="dex_title">Title</label>
               <input className="form-control" ref={(c) => this._title = c} name="dex_title" id="dex_title" type="text" maxLength="300" required placeholder="Living Dex" onChange={() => this.setState({ url: this._title.value })} />
               <i className="fa fa-asterisk" />

--- a/app/components/dex-create.jsx
+++ b/app/components/dex-create.jsx
@@ -2,7 +2,7 @@ import { Component } from 'react';
 import Modal         from 'react-modal';
 import { connect }   from 'react-redux';
 import { push }      from 'react-router-redux';
-import slug          from 'slug';
+import slugify       from 'slugify';
 
 import { AlertComponent } from './alert';
 import { ReactGA }        from '../utils/analytics';
@@ -73,7 +73,7 @@ export class DexCreate extends Component {
           <form onSubmit={this.onSubmit} className="form-column">
             <AlertComponent message={error} type="error" />
             <div className="form-group">
-              <div className="form-note">/u/{session.username}/{slug(url || 'Living Dex', { lower: true })}</div>
+              <div className="form-note">/u/{session.username}/{slugify(url || 'Living Dex', { lower: true })}</div>
               <label htmlFor="dex_title">Title</label>
               <input className="form-control" ref={(c) => this._title = c} name="dex_title" id="dex_title" type="text" maxLength="300" required placeholder="Living Dex" onChange={() => this.setState({ url: this._title.value })} />
               <i className="fa fa-asterisk" />

--- a/app/components/dex-edit.jsx
+++ b/app/components/dex-edit.jsx
@@ -1,7 +1,7 @@
 import { Component } from 'react';
 import Modal         from 'react-modal';
 import { connect }   from 'react-redux';
-import slug          from 'slug';
+import slugify       from 'slugify';
 
 import { AlertComponent }       from './alert';
 import { FormWarningComponent } from './form-warning';
@@ -76,7 +76,7 @@ export class DexEdit extends Component {
     const { dex } = this.props;
     const { url } = this.state;
 
-    return slug(url || 'Living Dex', { lower: true }) !== dex.slug;
+    return slugify(url || 'Living Dex', { lower: true }) !== dex.slug;
   }
 
   deleteDex = () => {
@@ -144,7 +144,7 @@ export class DexEdit extends Component {
           <form onSubmit={this.updateDex} className="form-column">
             <AlertComponent message={error} type="error" />
             <div className="form-group">
-              <div className="form-note">/u/{session.username}/{slug(url || 'Living Dex', { lower: true })}</div>
+              <div className="form-note">/u/{session.username}/{slugify(url || 'Living Dex', { lower: true })}</div>
               <label htmlFor="dex_title">Title</label>
               <FormWarningComponent message={this.showURLWarning ? URL_WARNING : null} />
               <input className="form-control" ref={(c) => this._title = c} name="dex_title" id="dex_title" type="text" maxLength="300" required placeholder="Living Dex" defaultValue={dex.title} onChange={() => this.setState({ url: this._title.value })} />

--- a/app/components/dex-edit.jsx
+++ b/app/components/dex-edit.jsx
@@ -1,12 +1,12 @@
 import { Component } from 'react';
 import Modal         from 'react-modal';
 import { connect }   from 'react-redux';
-import slugify       from 'slugify';
 
 import { AlertComponent }       from './alert';
 import { FormWarningComponent } from './form-warning';
 import { ReactGA }              from '../utils/analytics';
 import { deleteDex, updateDex } from '../actions/dex';
+import { slug }                 from '../utils/formatting';
 
 const GENERATION_WARNING = 'Any Gen 7 capture info will be lost.';
 const REGION_WARNING = 'Any non-Alola Dex capture info will be lost.';
@@ -76,7 +76,7 @@ export class DexEdit extends Component {
     const { dex } = this.props;
     const { url } = this.state;
 
-    return slugify(url || 'Living Dex', { lower: true }) !== dex.slug;
+    return slug(url || 'Living Dex') !== dex.slug;
   }
 
   deleteDex = () => {
@@ -144,7 +144,7 @@ export class DexEdit extends Component {
           <form onSubmit={this.updateDex} className="form-column">
             <AlertComponent message={error} type="error" />
             <div className="form-group">
-              <div className="form-note">/u/{session.username}/{slugify(url || 'Living Dex', { lower: true })}</div>
+              <div className="form-note">/u/{session.username}/{slug(url || 'Living Dex')}</div>
               <label htmlFor="dex_title">Title</label>
               <FormWarningComponent message={this.showURLWarning ? URL_WARNING : null} />
               <input className="form-control" ref={(c) => this._title = c} name="dex_title" id="dex_title" type="text" maxLength="300" required placeholder="Living Dex" defaultValue={dex.title} onChange={() => this.setState({ url: this._title.value })} />

--- a/app/utils/formatting.js
+++ b/app/utils/formatting.js
@@ -1,3 +1,5 @@
+import slugify from 'slugify';
+
 const FRIEND_CODE_REGEX = /(\d{4})(?=\d)/g;
 
 export function capitalize (input) {
@@ -14,4 +16,8 @@ export function friendCode (code) {
 
 export function padding (number, digits, value = '0') {
   return `${value.repeat(digits)}${number}`.slice(-1 * digits);
+}
+
+export function slug (str) {
+  return slugify(str, { lower: true, remove: /[^\w\s\-\.\_~]/g });
 }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "react-router-redux": "^4.0.8",
     "redux": "^3.6.0",
     "redux-thunk": "^2.2.0",
-    "slug": "^0.9.1"
+    "slugify": "^1.2.1"
   },
   "devDependencies": {
     "babel-core": "^6.23.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1056,22 +1056,6 @@ buffer@^4.3.0:
     ieee754 "^1.1.4"
     isarray "^1.0.0"
 
-"bufferjs@>= 2.0.0":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/bufferjs/-/bufferjs-3.0.1.tgz#0692e829cb10a10550e647390b035eb06c38e8ef"
-
-"bufferstream@>= 0.6.2":
-  version "0.6.2"
-  resolved "https://registry.yarnpkg.com/bufferstream/-/bufferstream-0.6.2.tgz#a5f27e10d3c760084d14b35126615007319e3731"
-  dependencies:
-    bufferjs ">= 2.0.0"
-  optionalDependencies:
-    buffertools ">= 1.0.3"
-
-"buffertools@>= 1.0.3":
-  version "2.1.4"
-  resolved "https://registry.yarnpkg.com/buffertools/-/buffertools-2.1.4.tgz#62d4e1584c0090a0c7d3587f25934a84b8b38de4"
-
 builtin-modules@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
@@ -4125,11 +4109,9 @@ slice-ansi@0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-0.0.4.tgz#edbf8903f66f7ce2f8eafd6ceed65e264c831b35"
 
-slug@^0.9.1:
-  version "0.9.1"
-  resolved "https://registry.yarnpkg.com/slug/-/slug-0.9.1.tgz#af08f608a7c11516b61778aa800dce84c518cfda"
-  dependencies:
-    unicode ">= 0.3.1"
+slugify@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/slugify/-/slugify-1.2.1.tgz#2118f4b0fbcfd79d7b2c451c22b724e5c1991330"
 
 sntp@1.x.x:
   version "1.0.9"
@@ -4469,12 +4451,6 @@ uglify-to-browserify@~1.0.0:
 uid-number@~0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/uid-number/-/uid-number-0.0.6.tgz#0ea10e8035e8eb5b8e4449f06da1c730663baa81"
-
-"unicode@>= 0.3.1":
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/unicode/-/unicode-0.6.1.tgz#ec69e3c4537e2b9650b826133bcb068f0445d0bc"
-  dependencies:
-    bufferstream ">= 0.6.2"
 
 uniq@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
\>^)))< ～～

switch the package we use for slugs cause the old one

- hasnt been updated in 2 years
- has a security vulnerability
- downloads unicode info from unicode.org on every install and if you do it too many times, unicode.org will rate limit you -_-
- it reduces `yarn` time by ~6 seconds which is good

i was working on the donation stuff but then i needed to upgrade some packages (pr for that coming soon) and then i got rate limited by unicode.org which led me here.

the functionality of this slugging module should stay the exact same tho!