### PR TITLE
chore(game): replace usage of generation/region with game/regional

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: node_js
 sudo: false
 env: 'CXX=g++-4.8'
 node_js:
-  - '5'
-  - '6'
+  - '5.12.0'
+cache: yarn
 addons:
   apt:
     sources:
@@ -12,4 +12,4 @@ addons:
       - gcc-4.8
       - g++-4.8
 script:
-  - npm run lint
+  - yarn lint

--- a/app/components/box.jsx
+++ b/app/components/box.jsx
@@ -10,10 +10,12 @@ export function Box ({ captures, dex }) {
   const empties = Array.from({ length: BOX_SIZE - captures.length }).map((_, i) => i);
   const firstPokemon = captures[0].pokemon;
   const lastPokemon = captures[captures.length - 1].pokemon;
-  let title = <h1>{padding(firstPokemon[`${dex.region}_id`], 3)} - {padding(lastPokemon[`${dex.region}_id`], 3)}</h1>;
+  let title = <h1>{firstPokemon.box}</h1>;
 
-  if (firstPokemon.box) {
-    title = <h1>{firstPokemon.box}</h1>;
+  if (!firstPokemon.box) {
+    const firstNumber = dex.regional ? firstPokemon[`${dex.game.game_family.id}_id`] : firstPokemon.national_id;
+    const lastNumber = dex.regional ? lastPokemon[`${dex.game.game_family.id}_id`] : lastPokemon.national_id;
+    title = <h1>{padding(firstNumber, 3)} - {padding(lastNumber, 3)}</h1>;
   }
 
   return (

--- a/app/components/dex-create.jsx
+++ b/app/components/dex-create.jsx
@@ -8,21 +8,23 @@ import { AlertComponent } from './alert';
 import { ReactGA }        from '../utils/analytics';
 import { createDex }      from '../actions/dex';
 
+const NATIONAL_ONLY_GAMES = ['x', 'y', 'omega_ruby', 'alpha_sapphire'];
+
 export class DexCreate extends Component {
 
   constructor (props) {
     super(props);
-    this.state = { error: null, generation: 7, region: 'national' };
+    this.state = { error: null, game: 'sun', regional: false };
   }
 
   onChange = (e) => {
-    const generation = parseInt(e.target.value);
+    const game = e.target.value;
 
-    if (generation === 6) {
-      this.setState({ region: 'national' });
+    if (NATIONAL_ONLY_GAMES.indexOf(game) > -1) {
+      this.setState({ regional: false });
     }
 
-    this.setState({ generation });
+    this.setState({ game });
   }
 
   scrollToTop () {
@@ -32,7 +34,7 @@ export class DexCreate extends Component {
   }
 
   onRequestClose = () => {
-    this.setState({ error: null, url: null, generation: 7, region: 'national' });
+    this.setState({ error: null, url: null, game: 'sun', regional: false });
     this.props.onRequestClose();
   }
 
@@ -40,12 +42,12 @@ export class DexCreate extends Component {
     e.preventDefault();
 
     const { createDex, redirect, session } = this.props;
-    const { generation, region } = this.state;
+    const { game, regional } = this.state;
     const title = this._title.value;
     const shiny = this._shiny.checked;
     const payload = {
       username: session.username,
-      payload: { title, shiny, generation, region }
+      payload: { title, shiny, game, regional }
     };
 
     this.setState({ ...this.state, error: null });
@@ -64,7 +66,7 @@ export class DexCreate extends Component {
 
   render () {
     const { isOpen, session } = this.props;
-    const { error, generation, region, url } = this.state;
+    const { error, game, regional, url } = this.state;
 
     return (
       <Modal className="modal" overlayClassName="modal-overlay" isOpen={isOpen} onRequestClose={this.onRequestClose} contentLabel="Create a New Dex">
@@ -80,23 +82,23 @@ export class DexCreate extends Component {
             </div>
             <div className="form-group">
               <label htmlFor="generation">Generation</label>
-              <select className="form-control" onChange={this.onChange} value={generation}>
-                <option value="7">Seven</option>
-                <option value="6">Six</option>
+              <select className="form-control" onChange={this.onChange} value={game}>
+                <option value="sun">Seven</option>
+                <option value="omega_ruby">Six</option>
               </select>
               <i className="fa fa-chevron-down" />
             </div>
             <div className="form-group">
-              <label htmlFor="region">Regionality</label>
+              <label htmlFor="regional">Regionality</label>
               <div className="radio">
                 <label>
-                  <input type="radio" name="region" checked={region === 'national'} value="national" onChange={() => this.setState({ region: 'national' })} />
+                  <input type="radio" name="regional" checked={!regional} value="national" onChange={() => this.setState({ regional: false })} />
                   <span className="radio-custom"><span /></span>National
                 </label>
               </div>
-              <div className={`radio ${generation === 6 ? 'disabled' : ''}`}>
-                <label title={generation === 6 ? 'Regional dexes only supported for Gen 7.' : ''}>
-                  <input type="radio" name="region" checked={region === 'alola'} disabled={generation === 6} value="alola" onChange={() => this.setState({ region: 'alola' })} />
+              <div className={`radio ${game === 'omega_ruby' ? 'disabled' : ''}`}>
+                <label title={game === 'omega_ruby' ? 'Regional dexes only supported for Gen 7.' : ''}>
+                  <input type="radio" name="regional" checked={regional} disabled={game === 'omega_ruby'} value="regional" onChange={() => this.setState({ regional: true })} />
                   <span className="radio-custom"><span /></span>Regional
                 </label>
               </div>

--- a/app/components/dex-indicator.jsx
+++ b/app/components/dex-indicator.jsx
@@ -14,8 +14,8 @@ export function DexIndicatorComponent ({ dex }) {
   return (
     <div className="dex-indicator">
       {shiny}
-      <span className="label">{dex.region === 'national' ? 'National' : 'Regional'}</span>
-      <span className="label">Gen {dex.generation}</span>
+      <span className="label">{dex.regional ? 'Regional' : 'National'}</span>
+      <span className="label">Gen {dex.game.game_family.generation}</span>
     </div>
   );
 }

--- a/app/components/info-locations.jsx
+++ b/app/components/info-locations.jsx
@@ -1,4 +1,4 @@
-export function InfoLocationsComponent ({ generation, pokemon, region }) {
+export function InfoLocationsComponent ({ gameFamily, pokemon, regional }) {
   const orLocations = (
     pokemon.or_locations.length === 0 ? <li><i>Not available</i></li> : pokemon.or_locations.map((location) => <li key={location}>{location}</li>)
   );
@@ -59,8 +59,8 @@ export function InfoLocationsComponent ({ generation, pokemon, region }) {
 
   return (
     <div className="info-locations">
-      {generation === 7 ? gen7 : null}
-      {region === 'national' ? gen6 : null}
+      {gameFamily.generation === 7 ? gen7 : null}
+      {regional ? null : gen6}
     </div>
   );
 }

--- a/app/components/info.jsx
+++ b/app/components/info.jsx
@@ -23,7 +23,7 @@ export class Info extends Component {
     const { currentPokemon, dex, pokemon, retrievePokemon } = this.props;
 
     if (!pokemon) {
-      retrievePokemon(currentPokemon, { generation: dex.generation, region: dex.region });
+      retrievePokemon(currentPokemon, { game_family: dex.game.game_family.id, regional: dex.regional });
     }
   }
 
@@ -37,7 +37,7 @@ export class Info extends Component {
 
   render () {
     const { dex, pokemon, showInfo } = this.props;
-    const serebiiPath = dex.generation === 6 ? 'pokedex-xy' : 'pokedex-sm';
+    const serebiiPath = dex.game.game_family.generation === 6 ? 'pokedex-xy' : 'pokedex-sm';
 
     if (!pokemon) {
       return (
@@ -64,7 +64,7 @@ export class Info extends Component {
             <h2>#{padding(pokemon.national_id, 3)}</h2>
           </div>
 
-          <InfoLocationsComponent generation={dex.generation} pokemon={pokemon} region={dex.region} />
+          <InfoLocationsComponent gameFamily={dex.game.game_family} pokemon={pokemon} regional={dex.regional} />
 
           <EvolutionFamilyComponent family={pokemon.evolution_family} />
 

--- a/app/components/region.jsx
+++ b/app/components/region.jsx
@@ -46,7 +46,7 @@ export class Region extends Component {
   render () {
     const { dex, mobile, region } = this.props;
 
-    if (dex.region !== 'national') {
+    if (dex.regional) {
       return null;
     }
 
@@ -56,7 +56,7 @@ export class Region extends Component {
       if (this.state.dropdown) {
         dropdown = (
           <div className="dropdown">
-            {REGIONS[dex.generation].map((r) => <div key={r} style={{ display: region === r ? 'none' : 'block' }} onClick={() => this.setRegion(r)}>{r}</div>)}
+            {REGIONS[dex.game.game_family.generation].map((r) => <div key={r} style={{ display: region === r ? 'none' : 'block' }} onClick={() => this.setRegion(r)}>{r}</div>)}
           </div>
         );
       }
@@ -74,7 +74,7 @@ export class Region extends Component {
 
     return (
       <div className="region-filter">
-        {REGIONS[dex.generation].map((r) => <div key={r} className={region === r ? 'active' : ''} onClick={() => this.setRegion(r)}>{r}</div>)}
+        {REGIONS[dex.game.game_family.generation].map((r) => <div key={r} className={region === r ? 'active' : ''} onClick={() => this.setRegion(r)}>{r}</div>)}
       </div>
     );
   }

--- a/app/components/register.jsx
+++ b/app/components/register.jsx
@@ -13,11 +13,13 @@ import { checkVersion, setNotification } from '../actions/utils';
 import { createUser }                    from '../actions/user';
 import { friendCode }                    from '../utils/formatting';
 
+const NATIONAL_ONLY_GAMES = ['x', 'y', 'omega_ruby', 'alpha_sapphire'];
+
 export class Register extends Component {
 
   constructor (props) {
     super(props);
-    this.state = { error: null, generation: 7, region: 'national' };
+    this.state = { error: null, game: 'sun', regional: false };
   }
 
   componentWillMount () {
@@ -31,13 +33,13 @@ export class Register extends Component {
   }
 
   onChange = (e) => {
-    const generation = parseInt(e.target.value);
+    const game = e.target.value;
 
-    if (generation === 6) {
-      this.setState({ region: 'national' });
+    if (NATIONAL_ONLY_GAMES.indexOf(game) > -1) {
+      this.setState({ regional: false });
     }
 
-    this.setState({ generation });
+    this.setState({ game });
   }
 
   scrollToTop () {
@@ -50,7 +52,7 @@ export class Register extends Component {
     e.preventDefault();
 
     const { register, setNotification } = this.props;
-    const { generation, region } = this.state;
+    const { game, regional } = this.state;
     const username = this._username.value;
     const password = this._password.value;
     const password_confirm = this._password_confirm.value;
@@ -60,7 +62,7 @@ export class Register extends Component {
 
     this.setState({ error: null });
 
-    register({ username, password, password_confirm, friend_code, title, shiny, generation, region })
+    register({ username, password, password_confirm, friend_code, title, shiny, game, regional })
     .then(() => {
       ReactGA.event({ action: 'register', category: 'Session' });
       setNotification(true);
@@ -72,7 +74,7 @@ export class Register extends Component {
   }
 
   render () {
-    const { error, generation, region } = this.state;
+    const { error, game, regional } = this.state;
 
     return (
       <DocumentTitle title="Register | Pokédex Tracker">
@@ -125,23 +127,23 @@ export class Register extends Component {
                   </div>
                   <div className="form-group">
                     <label htmlFor="generation">Generation</label>
-                    <select className="form-control" onChange={this.onChange} value={generation}>
-                      <option value="7">Seven</option>
-                      <option value="6">Six</option>
+                    <select className="form-control" onChange={this.onChange} value={game}>
+                      <option value="sun">Seven</option>
+                      <option value="omega_ruby">Six</option>
                     </select>
                     <i className="fa fa-chevron-down" />
                   </div>
                   <div className="form-group">
-                    <label htmlFor="region">Regionality</label>
+                    <label htmlFor="regional">Regionality</label>
                     <div className="radio">
                       <label>
-                        <input type="radio" name="region" checked={region === 'national'} value="national" onChange={() => this.setState({ region: 'national' })} />
+                        <input type="radio" name="regional" checked={!regional} value="national" onChange={() => this.setState({ regional: false })} />
                         <span className="radio-custom"><span /></span>National
                       </label>
                     </div>
-                    <div className={`radio ${generation === 6 ? 'disabled' : ''}`}>
-                      <label title={generation === 6 ? 'Regional dexes only supported for Gen 7.' : ''}>
-                        <input type="radio" name="region" checked={region === 'alola'} disabled={generation === 6} value="alola" onChange={() => this.setState({ region: 'alola' })} />
+                    <div className={`radio ${game === 'omega_ruby' ? 'disabled' : ''}`}>
+                      <label title={game === 'omega_ruby' ? 'Regional dexes only supported for Gen 7.' : ''}>
+                        <input type="radio" name="regional" checked={regional} disabled={game === 'omega_ruby'} value="regional" onChange={() => this.setState({ regional: true })} />
                         <span className="radio-custom"><span /></span>Regional
                       </label>
                     </div>

--- a/app/utils/pokemon.js
+++ b/app/utils/pokemon.js
@@ -10,7 +10,7 @@ export function groupBoxes (captures, dex) {
     const naturalBox = Math.ceil((i + 1) / BOX_SIZE) - 1;
     let box = Math.max(naturalBox, all.length - 1);
 
-    if (dex.region === 'national' && capture.pokemon.box !== lastBox) {
+    if (!dex.regional && capture.pokemon.box !== lastBox) {
       box++;
     }
 


### PR DESCRIPTION
( ⚆ _ ⚆ )

- change usage of `generation`/`region` to use `game`/`regional` instead since api is completely using those as the source of truth instead
  - mostly in user create, dex create, dex edit
  - there are still a few refs to the props, but its for the region filter that will be removed in the usum pr
- update some travis stuffs

to test, just make sure that everything behaves as normal! this is just an internals pr so nothing user-facing shouldve changed