### PR TITLE
fix(modal): make modal vertically scrollable

### DIFF
--- a/app/styles/main.scss
+++ b/app/styles/main.scss
@@ -688,8 +688,9 @@ reload div {
   @include overflow-y-scroll();
 
   position: relative;
-  margin: 100px auto;
+  margin: 10vh auto;
   width: 500px;
+  max-height: 80vh;
   border: 2px solid $brand-secondary-light;
   background: #fff;
   outline: none;


### PR DESCRIPTION
⌒ﾟ(❀>◞౪◟<)ﾟ⌒

- fixes https://github.com/pokedextracker/pokedextracker.com/issues/301
- makes modal always fit on 80% of the height of the screen and allows the rest of the content to be scrollable:
![image](https://user-images.githubusercontent.com/5498072/39962384-a9ab0fa0-5601-11e8-8f55-dc02b0da705a.png)
