### PR TITLE
fix(dropdown): add scroll for over 6 dexes

### DIFF
--- a/app/components/nav.jsx
+++ b/app/components/nav.jsx
@@ -60,8 +60,9 @@ export class Nav extends Component {
           <div className="dropdown">
             <a href="#">{session.username} <i className="fa fa-caret-down" /></a>
             <ul>
-              {user.dexes.map((dex) => <li key={dex.id}><Link to={`/u/${session.username}/${dex.slug}`}><i className="fa fa-th" /> {dex.title}</Link></li>)}
-
+              <div className="dropdown-scroll">
+                {user.dexes.map((dex) => <li key={dex.id}><Link to={`/u/${session.username}/${dex.slug}`}><i className="fa fa-th" /> {dex.title}</Link></li>)}
+              </div>
               <li><Link to={`/u/${session.username}`}><i className="fa fa-user" /> Profile</Link></li>
               <li><Link to="/account"><i className="fa fa-cog" /> Account Settings</Link></li>
               <li><a onClick={this.signOut}><i className="fa fa-sign-out" /> Sign Out</a></li>

--- a/app/styles/main.scss
+++ b/app/styles/main.scss
@@ -99,6 +99,11 @@ nav {
       }
     }
 
+    .dropdown-scroll {
+      max-height: 242px;
+      overflow-y: scroll;
+    }
+
     ul {
       @include transition(all .1s ease-out);
 


### PR DESCRIPTION
@(o・ェ・)@ノ

![image](https://user-images.githubusercontent.com/5498072/43376484-e399d4ca-936f-11e8-8dc7-3b15367930ab.png)

sets a max height on the dex list, purposely cuts it off at dex 6.5 to indicate to the user to scroll. i left the profile, settings, and sign out there always.

what do you think? i can always change it up, reorder things, etc.

fixes #305