### PR TITLE
feat(locations): use pokemon.locations to simplify logic

### DIFF
--- a/app/components/info-locations.jsx
+++ b/app/components/info-locations.jsx
@@ -1,89 +1,16 @@
-export function InfoLocationsComponent ({ gameFamily, pokemon, regional }) {
-  const orLocations = (
-    pokemon.or_locations.length === 0 ? <li><i>Not available</i></li> : pokemon.or_locations.map((location) => <li key={location}>{location}</li>)
-  );
-
-  const asLocations = (
-    pokemon.as_locations.length === 0 ? <li><i>Not available</i></li> : pokemon.as_locations.map((location) => <li key={location}>{location}</li>)
-  );
-
-  const xLocations = (
-    pokemon.x_locations.length === 0 ? <li><i>Not available</i></li> : pokemon.x_locations.map((location) => <li key={location}>{location}</li>)
-  );
-
-  const yLocations = (
-    pokemon.y_locations.length === 0 ? <li><i>Not available</i></li> : pokemon.y_locations.map((location) => <li key={location}>{location}</li>)
-  );
-
-  const sunLocations = (
-    pokemon.sun_locations.length === 0 ? <li><i>Not available</i></li> : pokemon.sun_locations.map((location) => <li key={location}>{location}</li>)
-  );
-
-  const moonLocations = (
-    pokemon.moon_locations.length === 0 ? <li><i>Not available</i></li> : pokemon.moon_locations.map((location) => <li key={location}>{location}</li>)
-  );
-
-  const ultraSunLocations = (
-    pokemon.us_locations.length === 0 ? <li><i>Not available</i></li> : pokemon.us_locations.map((location) => <li key={location}>{location}</li>)
-  );
-
-  const ultraMoonLocations = (
-    pokemon.um_locations.length === 0 ? <li><i>Not available</i></li> : pokemon.um_locations.map((location) => <li key={location}>{location}</li>)
-  );
-
-  const gen6 = (
-    <div>
-      <h3>Pokémon Omega Ruby</h3>
-      <ul>
-        {orLocations}
-      </ul>
-      <h3>Pokémon Alpha Sapphire</h3>
-      <ul>
-        {asLocations}
-      </ul>
-      <h3>Pokémon X</h3>
-      <ul>
-        {xLocations}
-      </ul>
-      <h3>Pokémon Y</h3>
-      <ul>
-        {yLocations}
-      </ul>
-    </div>
-  );
-
-  const sunMoon = (
-    <div>
-      <h3>Pokémon Sun</h3>
-      <ul>
-        {sunLocations}
-      </ul>
-      <h3>Pokémon Moon</h3>
-      <ul>
-        {moonLocations}
-      </ul>
-    </div>
-  );
-
-  const ultraSunUltraMoon = (
-    <div>
-      <h3>Pokémon Ultra Sun</h3>
-      <ul>
-        {ultraSunLocations}
-      </ul>
-      <h3>Pokémon Ultra Moon</h3>
-      <ul>
-        {ultraMoonLocations}
-      </ul>
-    </div>
-  );
-
-  // TODO: refactor this logic to more scalable and easier to understand
+export function InfoLocationsComponent ({ pokemon }) {
   return (
     <div className="info-locations">
-      {gameFamily.id === 'ultra_sun_ultra_moon' ? ultraSunUltraMoon : null}
-      {gameFamily.id === 'sun_moon' || (gameFamily.id === 'ultra_sun_ultra_moon' && !regional) ? sunMoon : null}
-      {!regional ? gen6 : null}
+      {pokemon.locations.map((location) => {
+        return (
+          <div key={location.game.id}>
+            <h3>Pokémon {location.game.name}</h3>
+            <ul>
+              {location.value.map((loc) => <li key={loc}>{loc}</li>)}
+            </ul>
+          </div>
+        );
+      })}
     </div>
   );
 }

--- a/app/components/info.jsx
+++ b/app/components/info.jsx
@@ -64,7 +64,7 @@ export class Info extends Component {
             <h2>#{padding(pokemon.national_id, 3)}</h2>
           </div>
 
-          <InfoLocationsComponent gameFamily={dex.game.game_family} pokemon={pokemon} regional={dex.regional} />
+          <InfoLocationsComponent pokemon={pokemon} />
 
           <EvolutionFamilyComponent family={pokemon.evolution_family} />
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -4,13 +4,12 @@ server {
 
   server_name localhost;
 
+  location /health {
+    return 200;
+  }
+
   # disregard port when redirecting
   port_in_redirect off;
-
-  # redirect http to https
-  if ($http_x_forwarded_proto = "http") {
-    return 301 https://$host$request_uri;
-  }
 
   # general settings
   charset UTF-8;
@@ -35,6 +34,11 @@ server {
 
   # redirect /blog traffic to the blog
   location ^~ /blog {
+    # redirect http to https
+    if ($http_x_forwarded_proto = "http") {
+      return 301 https://$host$request_uri;
+    }
+
     proxy_http_version 1.1;
     proxy_set_header Connection "Keep-Alive";
     proxy_set_header Proxy-Connection "Keep-Alive";
@@ -50,6 +54,11 @@ server {
 
   # disable cache and redirect urls that don't match a file to index.html
   location / {
+    # redirect http to https
+    if ($http_x_forwarded_proto = "http") {
+      return 301 https://$host$request_uri;
+    }
+
     add_header Pragma "no-cache";
     expires -1;
     try_files $uri $uri/ /;


### PR DESCRIPTION
( ¨̮ )

this is using the new `locations` array instead of the custom logic we had before. the main changes involve showing all locations for national dexes for the selected game's family's generation and below. so for the common case, the main change will be that it shows the usum locations for sumo national dexes.

i also added some health check stuff but that dont matter 