### PR TITLE
feat(games): use regional_support and national_support

### DIFF
--- a/app/actions/game.js
+++ b/app/actions/game.js
@@ -9,7 +9,10 @@ export function listGames () {
     dispatch(checkVersion());
 
     return API.get(`${Config.API_HOST}/games`)
-    .then((games) => dispatch(setGames(games)));
+    .then((games) => {
+      dispatch(setGames(games));
+      return games;
+    });
   };
 }
 

--- a/app/components/dex.jsx
+++ b/app/components/dex.jsx
@@ -19,7 +19,7 @@ export function Dex ({ captures, dex, onScrollButtonClick, query, username }) {
   const caught = captures.filter(({ captured }) => captured).length;
   const total = captures.length;
 
-  if (query.length === 0 && !BOX_COMPONENTS[dex.id]) {
+  if (query.length === 0) {
     const boxes = groupBoxes(captures, dex);
     BOX_COMPONENTS[dex.id] = boxes.map((box, i) => {
       if (i > DEFER_CUTOFF) {

--- a/app/reducers/games-by-id.js
+++ b/app/reducers/games-by-id.js
@@ -1,0 +1,14 @@
+import { SET_GAMES } from '../actions/game';
+
+export function gamesById (state = {}, action) {
+  switch (action.type) {
+    case SET_GAMES:
+      const gamesById = action.games.reduce((games, game) => {
+        return Object.assign({ [game.id]: game }, games);
+      }, {});
+
+      return gamesById;
+    default:
+      return state;
+  }
+}

--- a/app/reducers/index.js
+++ b/app/reducers/index.js
@@ -5,6 +5,7 @@ import { currentDex }     from './current-dex';
 import { currentPokemon } from './current-pokemon';
 import { currentUser }    from './current-user';
 import { games }          from './games';
+import { gamesById }      from './games-by-id';
 import { notification }   from './notification';
 import { pokemon }        from './pokemon';
 import { query }          from './query';
@@ -22,6 +23,7 @@ export const reducer = combineReducers({
   currentPokemon,
   currentUser,
   games,
+  gamesById,
   notification,
   pokemon,
   query,


### PR DESCRIPTION
°₊·ˈ∗(( ॣ>̶᷇ᗢ<̶᷆ ॣ))∗ˈ‧

- instead of relying on `NATIONAL_ONLY_GAMES`, rely on db value of `regional_support`
  - i also made the db have `regional_support = true` for xy, oras, sumo, and usum so we'll support regional gen 7 dexes as well
- rely on `national_support` to potentially not allow national dexes for a game. this isnt used now, but will be for lets go
- the default value for "new dex" is always the latest game
- change all references to specific games (e.g. the word alolan in various places)
- fixes #311 