### PR TITLE
feat(robots): disallow /u/ pages from being indexed

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /u/

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -13,7 +13,7 @@
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://pokedextracker.com/u/ashketchum10</loc>
-    <priority>0.6</priority>
+    <loc>https://pokedextracker.com/donate</loc>
+    <priority>0.8</priority>
   </url>
 </urlset>


### PR DESCRIPTION
(๏็ટૄ ๏็ (๏็ટૄ◟๏็ )

i was perusing our search console and i noticed that a ton of our search results are peoples profiles/dexes. and i think thats kinda lame, so we're just not gonna index them anymore.

i was wondering about ashketchum10, but tbh, i dont think thats a super valuable landing page anyway. if they hit the homepage, they can go to his profile that way instead of hitting it directly. and that way, they have more context into what the site is. but if you disagree, lmk!