### PR TITLE
fix(profile): wait for games to load

### DIFF
--- a/app/components/profile.jsx
+++ b/app/components/profile.jsx
@@ -41,10 +41,12 @@ export class Profile extends Component {
     checkVersion();
     setCurrentUser(username);
     setShowShare(false);
-    listGames();
 
-    retrieveUser(username)
-    .then((user) => {
+    Promise.all([
+      retrieveUser(username),
+      listGames()
+    ])
+    .then(([user]) => {
       setUser(user);
       this.setState({ ...this.state, loading: false });
     })


### PR DESCRIPTION
(´･(00)･｀)

while clicking through the site, id get an error every now and then complaining about `Cannot read property 'id' of undefined` resulting in the page not loading. according to sentry, this actually happens a lot. it looks like the root cause is because the dex create component assumes that the games have already been loaded, but since we werent waiting on it before marking `loading` as `false` in the profile, there was a race condition where the games werent loaded in time.

this change now waits on the games too before marking `loading` as `false`