### PR TITLE
chore(sprites): swap shellos and gastrodon forms

### DIFF
--- a/app/styles/index.scss
+++ b/app/styles/index.scss
@@ -1,8 +1,8 @@
 @import 'variables';
 @import 'mixins';
 @import 'animations';
+@import 'pokesprite';
 @import 'main';
 @import 'home';
 @import 'tracker';
 @import 'profile';
-@import 'pokesprite';

--- a/app/styles/tracker.scss
+++ b/app/styles/tracker.scss
@@ -605,6 +605,15 @@ header {
   }
 }
 
+.pkicon.pkicon-422 { width: 19px; height: 20px; background-position: -1005px -1904px; }
+.pkicon.pkicon-422.color-shiny { width: 19px; height: 20px; background-position: -1072px -1904px; }
+.pkicon.pkicon-422.form-east.color-shiny { width: 17px; height: 20px; background-position: -1139px -1904px; }
+.pkicon.pkicon-422.form-east { width: 17px; height: 20px; background-position: -1206px -1904px; }
+.pkicon.pkicon-423 { width: 23px; height: 22px; background-position: -1273px -1904px; }
+.pkicon.pkicon-423.color-shiny { width: 23px; height: 22px; background-position: -1340px -1904px; }
+.pkicon.pkicon-423.form-east.color-shiny { width: 23px; height: 22px; background-position: -1407px -1904px; }
+.pkicon.pkicon-423.form-east { width: 23px; height: 22px; background-position: -1474px -1904px; }
+
 @media (min-width: 751px) {
   .search-results .pokemon {
     margin-left: -2px;


### PR DESCRIPTION
ε-(‘ﾍ´○)┓

set default shellos/gastrodon to east sea, since explicitly only east sea shellos can be captured in swsh. this also sets east sea to be the only form on all other dexes, but that's fine since we don't track forms currently anyway.

normal:
![image](https://user-images.githubusercontent.com/5498072/71292620-e839fd80-2328-11ea-82a6-36dfad4b036f.png)

shiny:
![image](https://user-images.githubusercontent.com/5498072/71293048-11f32480-2329-11ea-8fd2-1ad470dae9a6.png)