### PR TITLE
Hide captured pokemon when "Hide pokemon" is checked

### DIFF
--- a/app/actions/search.js
+++ b/app/actions/search.js
@@ -1,5 +1,10 @@
 export const SET_QUERY = 'SET_QUERY';
+export const TOGGLE_FILTER_COMPLETED = 'TOGGLE_FILTER_COMPLETED';
 
 export function setQuery (query) {
   return { type: SET_QUERY, query };
+}
+
+export function toggleFilterCompleted () {
+  return { type: TOGGLE_FILTER_COMPLETED };
 }

--- a/app/components/box.jsx
+++ b/app/components/box.jsx
@@ -5,10 +5,22 @@ import { PokemonComponent }       from './pokemon';
 import { deferComponentRender }   from '../utils/defer-component-render';
 import { padding }                from '../utils/formatting';
 
-export const BOX_SIZE = 30;
+export const STANDARD_BOX_SIZE = 30;
 
-export function Box ({ captures, dex }) {
-  const empties = Array.from({ length: BOX_SIZE - captures.length }).map((_, i) => i);
+export function Box ({ captures, dex, hideCompleted }) {
+  const showPokemon = showPokemonCurried(hideCompleted);
+  const pokemonToShow = captures.filter((capture) => showPokemon(capture));
+  let BOX_SIZE;
+  // We want to have every box in a line filled, but no need to add extra lines if we don't need to
+  if (pokemonToShow.length % 6 === 0) {
+    BOX_SIZE = pokemonToShow.length;
+  } else {
+    BOX_SIZE = pokemonToShow.length + (6 - (pokemonToShow.length % 6))
+  }
+  if (BOX_SIZE === 0) {
+    return null;
+  }
+  const empties = Array.from({ length: BOX_SIZE - pokemonToShow.length }).map((_, i) => i);
   const firstPokemon = captures[0].pokemon;
   const lastPokemon = captures[captures.length - 1].pokemon;
   let title = <h1>{firstPokemon.box}</h1>;
@@ -26,15 +38,23 @@ export function Box ({ captures, dex }) {
         <MarkAllButtonComponent captures={captures} />
       </div>
       <div className="box-container">
-        {captures.map((capture) => <PokemonComponent key={capture.pokemon.id} capture={capture} />)}
+        {pokemonToShow.map((capture) => <PokemonComponent key={capture.pokemon.id} capture={capture} />)}
         {empties.map((index) => <PokemonComponent key={index} capture={null} />)}
       </div>
     </div>
   );
 }
 
-function mapStateToProps ({ currentDex, currentUser, users }) {
-  return { dex: users[currentUser].dexesBySlug[currentDex] };
+const showPokemonCurried = (hideCompleted) => (capture) => {
+  if (!hideCompleted) {
+    return true;
+  } else {
+    return !capture.captured;
+  }
+}
+
+function mapStateToProps ({ currentDex, currentUser, users, hideCompleted }) {
+  return { dex: users[currentUser].dexesBySlug[currentDex], hideCompleted };
 }
 
 export const DeferredBoxComponent = deferComponentRender(connect(mapStateToProps)(Box));

--- a/app/components/search-bar.jsx
+++ b/app/components/search-bar.jsx
@@ -2,7 +2,7 @@ import { Component } from 'react';
 import { connect }   from 'react-redux';
 
 import { ReactGA }  from '../utils/analytics';
-import { setQuery } from '../actions/search';
+import { setQuery, toggleFilterCompleted } from '../actions/search';
 
 export class SearchBar extends Component {
 
@@ -28,7 +28,7 @@ export class SearchBar extends Component {
   }
 
   render () {
-    const { query, setQuery } = this.props;
+    const { query, setQuery, filterCompleted, toggleFilterCompleted } = this.props;
 
     if (this._search) {
       this._search.value = query;
@@ -42,6 +42,10 @@ export class SearchBar extends Component {
             <input className="form-control" ref={(c) => this._search = c} name="search" id="search" type="text" placeholder="Search by Pokémon name (press / to quick search)" autoComplete="off" autoCorrect="off" autoCapitalize="off" spellCheck="false" onChange={(e) => setQuery(e.target.value)} />
             {query.length > 0 ? <a onClick={this.onClick}><i className="fa fa-times" /></a> : null}
           </div>
+          <div className="form-group">
+            <input className="form-control" name="filter-completed" id="filter-completed" type="checkbox" onChange={(e) => toggleFilterCompleted()} checked={filterCompleted} />
+            Hide Completed
+          </div>
         </div>
       </div>
     );
@@ -49,13 +53,14 @@ export class SearchBar extends Component {
 
 }
 
-function mapStateToProps ({ query }) {
+function mapStateToProps ({ query, filterCompleted }) {
   return { query };
 }
 
 function mapDispatchToProps (dispatch) {
   return {
-    setQuery: (query) => dispatch(setQuery(query))
+    setQuery: (query) => dispatch(setQuery(query)),
+    toggleFilterCompleted: (query) => dispatch(toggleFilterCompleted(query))
   };
 }
 

--- a/app/reducers/hide-completed.js
+++ b/app/reducers/hide-completed.js
@@ -1,0 +1,10 @@
+import { TOGGLE_FILTER_COMPLETED } from '../actions/search';
+
+export function hideCompleted (state = false, action) {
+  switch (action.type) {
+    case TOGGLE_FILTER_COMPLETED:
+      return !state;
+    default:
+      return state;
+  }
+}

--- a/app/reducers/index.js
+++ b/app/reducers/index.js
@@ -9,6 +9,7 @@ import { gamesById }      from './games-by-id';
 import { notification }   from './notification';
 import { pokemon }        from './pokemon';
 import { query }          from './query';
+import { hideCompleted }  from './hide-completed';
 import { reload }         from './reload';
 import { sessionUser }    from './session-user';
 import { session }        from './session';
@@ -26,6 +27,7 @@ export const reducer = combineReducers({
   gamesById,
   notification,
   pokemon,
+  hideCompleted,
   query,
   reload,
   routing: routerReducer,

--- a/app/styles/main.scss
+++ b/app/styles/main.scss
@@ -350,7 +350,7 @@ form {
   }
 }
 
-.form-control,
+.form-control:not([type='checkbox']),
 select {
   width: 100%;
   -webkit-appearance: none;
@@ -383,7 +383,7 @@ select {
     letter-spacing: 1px;
   }
 
-  .form-control,
+  .form-control:not([type='checkbox']),
   select {
     height: 43px;
     padding: 0 32px 0 10px;

--- a/app/styles/tracker.scss
+++ b/app/styles/tracker.scss
@@ -250,7 +250,7 @@
   .form-group {
     margin-bottom: 0;
 
-    input {
+    input#search {
       padding-left: 32px;
     }
 

--- a/app/utils/pokemon.js
+++ b/app/utils/pokemon.js
@@ -1,13 +1,13 @@
 import classNames from 'classnames';
 
-import { BOX_SIZE } from '../components/box';
+import { STANDARD_BOX_SIZE } from '../components/box';
 import { padding }  from './formatting';
 
 export function groupBoxes (captures) {
   let lastBox = null;
 
   return captures.reduce((all, capture, i) => {
-    const naturalBox = Math.ceil((i + 1) / BOX_SIZE) - 1;
+    const naturalBox = Math.ceil((i + 1) / STANDARD_BOX_SIZE) - 1;
     let box = Math.max(naturalBox, all.length - 1);
 
     if (capture.pokemon.box !== lastBox) {


### PR DESCRIPTION
I added a small feature to allow people to hide captured pokemon. 

I put it under the search bar, but not sure if you can think of a better place for it to go.

A few things that probably need to be done:
- [ ] Fix styling issues, it looks kinda ugly, probably need to make it nicer
- [ ] Probably save the setting in local storage - it currently gets cleared, just like the seearch query, but this probably makes more sense to persist

In terms of how this works, I made a few design decisions. Feel free to tell me I'm wrong with any one them.

Firstly, the [default view](https://files.yamanickill.com/gu81AvsK.png) looks exactly the same, just with the "hide completed" checkbox appearing under the search box.

When you check this, [those pokemon are hidden from view](https://files.yamanickill.com/pJFXLIiH.png). We just don't render them.

You'll notice that it doesn't show all 30 spaces in this screenshot. It would defeat the purpose of this feature to do so, as you'll jsut end up with boxes of 30 empty, which makes you scroll as much as you would before. So I've basically modulo-ed the boxes to 6. So if there are 28 in it, you'll get 30 spaces, but if there's 1, you'll get 6, 8, you'll get 12, etc.

This also lowers the whitespace for the [alola/galar sections](https://files.yamanickill.com/RzyRI-RN.png), they take up fewer rows now.

Next, [when you have a box fully done](https://files.yamanickill.com/qFqydPO-.png), it'll completely hide from view. I thought this made most sense as possibly seeing a box with no pokemon would be a bit confusing, and if you are selecting "Hide Completed" it'll be to save space and mental calculations on looking through the list. So this made most sense to me.

Thanks for the website, I really like it, and thought I'd add the code for this feature that I'd really like. Happy to modify things as you want. Let me know if you want this feature or not. As shown above, there are a couple of things I need to do before this would be ready for merge anyway, but thought I'd get it up now before I spend too much time pouring over CSS.