### PR TITLE
fix(docker): set NODE_ENV to be production to uglify bundle

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM node:6.12.3 as build
 
+ENV NODE_ENV=production
+
 RUN mkdir /app
 WORKDIR /app
 
@@ -10,7 +12,7 @@ RUN yarn --production --silent
 COPY . .
 RUN yarn build
 
-FROM nginx:1.13.8-alpine
+FROM nginx:1.17.8-alpine
 
 RUN rm -f /etc/nginx/conf.d/default.conf
 COPY nginx.conf /etc/nginx/conf.d/dashboard.conf


### PR DESCRIPTION
(๑°o°๑)

set `NODE_ENV` to `production` so that the `bundle.js` gets minified and uglified. currently, the `bundle.js` is ~10.3MB (gzipped: ~1.7MB), and with this change it's now ~2.5MB (gzipped: ~272KB) which is ~6.5x improvement. this should help reduce some data transfer costs

i also updated nginx cause why not

just gonna merge this since its a small change!