### PR TITLE
fix(config): change priority of environment

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -15,6 +15,6 @@ const ENVIRONMENTS = {
   'staging.pokedextracker.com': 'staging'
 };
 
-const environment = process.env.NODE_ENV || ENVIRONMENTS[window.location.hostname] || 'development';
+const environment = ENVIRONMENTS[window.location.hostname] || process.env.NODE_ENV || 'development';
 
 export const Config = CONFIG[environment];


### PR DESCRIPTION
(⁎˃ᆺ˂)

when i deployed #365 to staging, it didn't work cause now, we're always hardcoding production for the deployed versions. so i reordered the environment checks so that it will always pull the correct environment in staging and production (based on the hostnames), and then it will look for any `NODE_ENV` (so that `NODE_ENV=local yarn start` will still work), and lastly, it will default to `development` (so that `yarn start` still hits staging api). so i think this fixes everything

merging againnn