### PR TITLE
feat(deploy): add cache busting

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -18,9 +18,10 @@ node_modules
 typings
 
 coverage
-bundle.js
-*.map
-version
+public/*.js
+public/*.map
+public/version
+public/index.html
 
 .idea/
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -18,9 +18,10 @@ node_modules
 typings
 
 coverage
-bundle.js
-*.map
-version
+public/*.js
+public/*.map
+public/version
+public/index.html
 
 .idea/
 .DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM node:12.16.1 as build
 
 ENV NODE_ENV=production
-ARG VERSION=development
 
 RUN mkdir /app
 WORKDIR /app
@@ -15,6 +14,9 @@ COPY webpack.config.js webpack.config.js
 COPY config config
 COPY public public
 COPY app app
+
+ARG VERSION=development
+
 RUN yarn build
 
 FROM nginx:1.17.9-alpine

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,7 +9,7 @@ module.exports = {
   entry: './app/index.jsx',
   output: {
     path: `${__dirname}/public`,
-    filename: 'bundle.js',
+    filename: '[name].[contenthash].js',
     publicPath: '/'
   },
   resolve: {


### PR DESCRIPTION
(꒪ȏ꒪)ｴｯ?

- we're seeing a lot of errors on older versions of the code (code that was deployed months ago). my suspicion is that it's just an aggressive browser that causing it, so by adding some basic cache busting (following [this](https://webpack.js.org/guides/caching/)), it will help it. however, i'm not 100% sure about this. cause if the `index.html` is the thing that's being cached and not the `bundle.js`, then it will continue to pull the old `index.html` because it's hard to cache bust that. though our headers should already be doing that, so let's hope that all works.
- refine .gitignore and `.dockerignore` to handle the new files generated through the cache busting
- [unrelated] move the build arg further down in the `Dockerfile` so that we can better use docker cache when building locally
- [unrelated] have the deploy script specify kube context to avoid deploying to the wrong cluster