### PR TITLE
fix(fetch): add fetch polyfill

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
     "slug": "^2.1.1",
     "style-loader": "^1.1.3",
     "webpack": "^4.42.0",
-    "webpack-cli": "^3.3.11"
+    "webpack-cli": "^3.3.11",
+    "whatwg-fetch": "^3.0.0"
   },
   "devDependencies": {
     "babel-eslint": "^10.1.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,7 +6,7 @@ const Webpack           = require('webpack');
 const PRODUCTION = process.env.NODE_ENV === 'staging' || process.env.NODE_ENV === 'production';
 
 module.exports = {
-  entry: './app/index.jsx',
+  entry: ['whatwg-fetch', './app/index.jsx'],
   output: {
     path: `${__dirname}/public`,
     filename: '[name].[contenthash].js',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,7 +9,7 @@ module.exports = {
   entry: ['whatwg-fetch', './app/index.jsx'],
   output: {
     path: `${__dirname}/public`,
-    filename: '[name].[contenthash].js',
+    filename: PRODUCTION ? '[name].[contenthash].js' : '[name].[hash].js',
     publicPath: '/'
   },
   resolve: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6849,6 +6849,11 @@ whatwg-fetch@>=0.10.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz#9c84ec2dcf68187ff00bc64e1274b442176e1c84"
 
+whatwg-fetch@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz#fc804e458cc460009b1a2b966bc8817d2578aefb"
+  integrity sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q==
+
 which-module@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-1.0.0.tgz#bba63ca861948994ff307736089e3b96026c2a4f"


### PR DESCRIPTION
(／\_^)／ 　　　　　　●　＼(^\_＼)

- during the react upgrade, i removed `isomorphic-fetch` from our dependencies cause i thought that `fetch` was pretty mainstream at this point, and we could remove an extra dependency. since that change was deployed, we have seen some `'fetch' is undefined` errors. and when looking at the browser breakdown, its only IE browsers and Edge 13. thats cause IE never supported `fetch` and Edge only got it in version 14. so it checks out. there isnt a lot of traffic with these browsers, but might as well add this tiny polyfill to support it. and i went directly to `whatwg-fetch` this time cause its supported by github instead of `isomorphic-fetch` which hasn't been updated since 2016.
- with my cache busting PR, i broke being able to run it locally. this fixes that.