### PR TITLE
fix(nginx): refine caching

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -30,7 +30,16 @@ server {
 
   # gzip
   gzip on;
-  gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
+  gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss image/svg+xml text/javascript;
+
+  # don't include assets when disabling the cache
+  location ~* \.(jpg|png)$ {}
+
+  # disable cache for css and js
+  location ~* \.(js|css)$ {
+    add_header Pragma "no-cache";
+    expires -1;
+  }
 
   # disable cache and redirect URLs that don't match a file to index.html
   location / {


### PR DESCRIPTION
(*′☉.̫☉)

- gzip svgs in addition to the other mime types
- for images: cache it normally
- for images and jss/css: dont have a `try_files` directive which will end up returning the contents of `index.html`. we want this for most urls e.g. `/login` should still return the contents of `index.html` so that react router can take over and display the correct page. but we dont want assets to do that. i have a feeling this might be whats cause so many old versions of the code to still be out in the wild. hopefully, if it accurately returns a 404, it will indicate to the browser that it needs to refetch things