### PR TITLE
feat(info): add ability to specify info links in footer

### DIFF
--- a/app/components/account.jsx
+++ b/app/components/account.jsx
@@ -32,6 +32,8 @@ export function Account () {
   const [passwordConfirm, setPasswordConfirm] = useState('');
   const [friendCode3ds, setFriendCode3ds] = useState(user && user.friend_code_3ds);
   const [friendCodeSwitch, setFriendCodeSwitch] = useState(user && user.friend_code_switch);
+  const [firstPokemonDB, setFirstPokemonDB] = useState(user && user.firstPokemonDB);
+  const [secondPokemonDB, setSecondPokemonDB] = useState(user && user.secondPokemonDB);
   const [success, setSuccess] = useState(null);
 
   useEffect(() => {
@@ -61,7 +63,9 @@ export function Account () {
         password,
         password_confirm: passwordConfirm,
         friend_code_3ds: friendCode3ds,
-        friend_code_switch: friendCodeSwitch
+        friend_code_switch: friendCodeSwitch,
+        first_pokemon_db: firstPokemonDB,
+        second_pokemon_db: secondPokemonDB
       }
     };
 
@@ -86,6 +90,8 @@ export function Account () {
   const handlePasswordConfirmChange = (e) => setPasswordConfirm(e.target.value);
   const handleFriendCode3dsChange = (e) => setFriendCode3ds(friendCode3dsFormatter(e.target.value));
   const handleFriendCodeSwitchChange = (e) => setFriendCodeSwitch(friendCodeSwitchFormatter(e.target.value));
+  const handleFirstPokemonDBChange = (e) => setFirstPokemonDB(e.target.value);
+  const handleSecondPokemonDBChange = (e) => setSecondPokemonDB(e.target.value);
 
   return (
     <div className="account-container">
@@ -164,6 +170,34 @@ export function Account () {
             <label htmlFor="language">Pokémon Name Language</label>
             <select className="form-control">
               <option>English</option>
+            </select>
+            <FontAwesomeIcon icon={faChevronDown} />
+          </div>
+          <div className="form-group">
+            <label htmlFor="first_pokemon_db">First Pokémon Info Link</label>
+            <select
+              className="form-control"
+              id="first_pokemon_db"
+              name="first_pokemon_db"
+              onChange={handleFirstPokemonDBChange}
+              value={firstPokemonDB}>
+              <option>Bulbapedia</option>
+              <option>Serebii</option>
+              <option>PokemonDB</option>
+            </select>
+            <FontAwesomeIcon icon={faChevronDown} />
+          </div>
+          <div className="form-group">
+            <label htmlFor="second_pokemon_db">Second Pokémon Info Link</label>
+            <select
+              className="form-control"
+              id="second_pokemon_db"
+              name="second_pokemon_db"
+              onChange={handleSecondPokemonDBChange}
+              value={secondPokemonDB}>
+              <option>Bulbapedia</option>
+              <option>Serebii</option>
+              <option>PokemonDB</option>
             </select>
             <FontAwesomeIcon icon={faChevronDown} />
           </div>

--- a/app/components/info-link.jsx
+++ b/app/components/info-link.jsx
@@ -1,0 +1,66 @@
+import find                    from 'lodash/find';
+import { faLongArrowAltRight } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon }     from '@fortawesome/react-fontawesome';
+import { useSelector }         from 'react-redux';
+import { useMemo }             from 'react';
+
+import { ReactGA }             from '../utils/analytics';
+import { padding }             from '../utils/formatting';
+
+export function InfoLink ({ site, pokemon }) {
+  const dex = useSelector(({ currentDex, currentUser, users }) => users[currentUser].dexesBySlug[currentDex]);
+  const SEREBII_LINKS = {
+    x_y: 'pokedex-xy',
+    omega_ruby_alpha_sapphire: 'pokedex-xy',
+    sun_moon: 'pokedex-sm',
+    ultra_sun_ultra_moon: 'pokedex-sm',
+    lets_go_pikachu_eevee: 'pokedex-sm',
+    sword_shield: 'pokedex-swsh',
+    sword_shield_expansion_pass: 'pokedex-swsh'
+  };
+
+  const serebiiPath = useMemo(() => {
+    if (!pokemon) {
+      return null;
+    }
+
+    const swshLocation = find(pokemon.locations, (loc) => loc.game.game_family.id === 'sword_shield');
+
+    // If the Pokemon's location is 'Currently unavailable' for SwSh, that means
+    // they aren't available in this game because of dexit, so we go back to the
+    // the SuMo Serebii links. This will probably need to be updating with
+    // future generations.
+    if (swshLocation && swshLocation.value.length > 0 && swshLocation.value[0] === 'Currently unavailable') {
+      return 'pokedex-sm';
+    }
+
+    return SEREBII_LINKS[dex.game.game_family.id];
+  }, [dex, pokemon]);
+
+  switch (site) {
+    case 'Bulbapedia':
+      return (<a href={`https://bulbapedia.bulbagarden.net/wiki/${encodeURI(pokemon.name)}_(Pok%C3%A9mon)`}
+        onClick={() => ReactGA.event({ action: 'open Bulbapedia link', category: 'Info', label: pokemon.name })}
+        rel="noopener noreferrer"
+        target="_blank">
+        Bulbapedia <FontAwesomeIcon icon={faLongArrowAltRight} />
+      </a>
+      );
+    case 'Serebii':
+      return (<a href={`https://www.serebii.net/${serebiiPath}/${padding(pokemon.national_id, 3)}.shtml`}
+        onClick={() => ReactGA.event({ action: 'open Serebii link', category: 'Info', label: pokemon.name })}
+        rel="noopener noreferrer"
+        target="_blank">
+        Serebii <FontAwesomeIcon icon={faLongArrowAltRight} />
+      </a>
+      );
+    case 'PokemonDB':
+      return (<a href={`https://pokemondb.net/pokedex/${encodeURI(pokemon.name)}`}
+        onClick={() => ReactGA.event({ action: 'open PokemonDB link', category: 'Info', label: pokemon.name })}
+        rel="noopener noreferrer"
+        target="_blank">
+        PokémonDB <FontAwesomeIcon icon={faLongArrowAltRight} />
+      </a>
+      );
+  }
+}

--- a/app/components/info.jsx
+++ b/app/components/info.jsx
@@ -1,26 +1,16 @@
-import find                                               from 'lodash/find';
-import { FontAwesomeIcon }                                from '@fortawesome/react-fontawesome';
-import { faCaretLeft, faCaretRight, faLongArrowAltRight } from '@fortawesome/free-solid-svg-icons';
-import { useDispatch, useSelector }                       from 'react-redux';
-import { useEffect, useMemo }                             from 'react';
+import { FontAwesomeIcon }           from '@fortawesome/react-fontawesome';
+import { faCaretLeft, faCaretRight } from '@fortawesome/free-solid-svg-icons';
+import { useDispatch, useSelector }  from 'react-redux';
+import { useEffect }        from 'react';
 
 import { EvolutionFamily }     from './evolution-family';
+import { InfoLink }            from './info-link';
 import { InfoLocations }       from './info-locations';
 import { ReactGA }             from '../utils/analytics';
 import { htmlName, iconClass } from '../utils/pokemon';
 import { padding }             from '../utils/formatting';
 import { retrievePokemon }     from '../actions/pokemon';
 import { setShowInfo }         from '../actions/tracker';
-
-const SEREBII_LINKS = {
-  x_y: 'pokedex-xy',
-  omega_ruby_alpha_sapphire: 'pokedex-xy',
-  sun_moon: 'pokedex-sm',
-  ultra_sun_ultra_moon: 'pokedex-sm',
-  lets_go_pikachu_eevee: 'pokedex-sm',
-  sword_shield: 'pokedex-swsh',
-  sword_shield_expansion_pass: 'pokedex-swsh'
-};
 
 export function Info () {
   const dispatch = useDispatch();
@@ -29,6 +19,7 @@ export function Info () {
   const dex = useSelector(({ currentDex, currentUser, users }) => users[currentUser].dexesBySlug[currentDex]);
   const pokemon = useSelector(({ currentPokemon, pokemon }) => pokemon[currentPokemon]);
   const showInfo = useSelector(({ showInfo }) => showInfo);
+  const user = useSelector(({ currentUser, users }) => users[currentUser]);
 
   useEffect(() => {
     if (!pokemon) {
@@ -38,24 +29,6 @@ export function Info () {
       }));
     }
   }, [currentPokemon, dex, pokemon]);
-
-  const serebiiPath = useMemo(() => {
-    if (!pokemon) {
-      return null;
-    }
-
-    const swshLocation = find(pokemon.locations, (loc) => loc.game.game_family.id === 'sword_shield');
-
-    // If the Pokemon's location is 'Currently unavailable' for SwSh, that means
-    // they aren't available in this game because of dexit, so we go back to the
-    // the SuMo Serebii links. This will probably need to be updating with
-    // future generations.
-    if (swshLocation && swshLocation.value.length > 0 && swshLocation.value[0] === 'Currently unavailable') {
-      return 'pokedex-sm';
-    }
-
-    return SEREBII_LINKS[dex.game.game_family.id];
-  }, [dex, pokemon]);
 
   const handleInfoClick = () => {
     ReactGA.event({ action: showInfo ? 'collapse' : 'uncollapse', category: 'Info' });
@@ -92,22 +65,8 @@ export function Info () {
         <EvolutionFamily family={pokemon.evolution_family} />
 
         <div className="info-footer">
-          <a
-            href={`http://bulbapedia.bulbagarden.net/wiki/${encodeURI(pokemon.name)}_(Pok%C3%A9mon)`}
-            onClick={() => ReactGA.event({ action: 'open Bulbapedia link', category: 'Info', label: pokemon.name })}
-            rel="noopener noreferrer"
-            target="_blank"
-          >
-            Bulbapedia <FontAwesomeIcon icon={faLongArrowAltRight} />
-          </a>
-          <a
-            href={`http://www.serebii.net/${serebiiPath}/${padding(pokemon.national_id, 3)}.shtml`}
-            onClick={() => ReactGA.event({ action: 'open Serebii link', category: 'Info', label: pokemon.name })}
-            rel="noopener noreferrer"
-            target="_blank"
-          >
-            Serebii <FontAwesomeIcon icon={faLongArrowAltRight} />
-          </a>
+          <InfoLink pokemon={pokemon} site={user.firstPokemonDB} />
+          <InfoLink pokemon={pokemon} site={user.secondPokemonDB} />
         </div>
       </div>
     </div>


### PR DESCRIPTION
Fixes #147 

- Adds a setting to the account menu to choose between Bulbapedia/Serebii/PokemonDB for links in the Info footer
- Uses this setting to display the correct link
- Adds support for PokemonDB
- Refactors the Info footer links into its own component, incorporating the Serebii dex-naming code

This is mostly tested - I can't quite work out how to point it at my local version of the API so haven't done a full end to end test, but it works when manually setting `site="PokemonDB"` in the new `InfoLink` component. 

It also doesn't implement PokeWiki.de or PokePedia.fr as those will require Pokemon name localisation before implementing, given their URLs use the German/French Pokemon names.