### PR TITLE
fix(cache): adjust our caching policies

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -32,19 +32,23 @@ server {
   gzip on;
   gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss image/svg+xml text/javascript;
 
-  # don't include assets when disabling the cache
-  location ~* \.(jpg|png)$ {}
-
-  # disable cache for css and js
-  location ~* \.(js|css)$ {
-    add_header Pragma "no-cache";
-    expires -1;
-  }
+  # Don't include assets when disabling the cache. We do this because:
+  # - We add a content hash to our JS assets.
+  # - Our images (including our spritesheet) are versioned.
+  # - Most of our styles are injected as a style element.
+  location ~* \.(jpg|png|js|css)$ {}
 
   # disable cache and redirect URLs that don't match a file to index.html
   location / {
-    add_header Pragma "no-cache";
-    expires -1;
+    # This is to disable the cache. We might only need the Cache-Control header,
+    # but caching is my enemy and I want to make sure it's turned off. Pulled
+    # from https://stackoverflow.com/a/45285696.
+    add_header Last-Modified $date_gmt;
+    add_header Cache-Control 'no-store, no-cache';
+    if_modified_since off;
+    expires off;
+    etag off;
+
     try_files $uri $uri/ /;
   }
 }


### PR DESCRIPTION
### what

- hopefully make the no-caching we have for our html better so we really dont cache it
- make sure we are caching our bundle js since we've added the content hash to the file a while ago, so if it changes, it will have a different hash. the fetching of that new file should be handled by the fact that we're not caching the html (since that's what references the js file name), but since the filenames are unique (instead of always being called `bundle.js` or something, we actually do want to cache it. it shouldn't change. and it could save us some bandwidth costs.