### PR TITLE
feat(slug): pass slug through to backend

### DIFF
--- a/app/components/dex-create.jsx
+++ b/app/components/dex-create.jsx
@@ -69,7 +69,7 @@ export function DexCreate ({ isOpen, onRequestClose }) {
 
     const payload = {
       username: session.username,
-      payload: { title, shiny, game, dex_type: dexType }
+      payload: { title, slug: slug(title, { lower: true }), shiny, game, dex_type: dexType }
     };
 
     setError(null);

--- a/app/components/dex-edit.jsx
+++ b/app/components/dex-edit.jsx
@@ -131,7 +131,13 @@ export function DexEdit ({ dex, isOpen, onRequestClose }) {
     const payload = {
       slug: dex.slug,
       username: session.username,
-      payload: { title, shiny, game, dex_type: dexType }
+      payload: {
+        title,
+        slug: title !== dex.title ? slug(title, { lower: true }) : undefined,
+        shiny,
+        game,
+        dex_type: dexType
+      }
     };
 
     setError(null);

--- a/app/components/register.jsx
+++ b/app/components/register.jsx
@@ -73,6 +73,7 @@ export function Register () {
       friend_code_3ds: friendCode3ds,
       friend_code_switch: friendCodeSwitch,
       title,
+      slug: slug(title, { lower: true }),
       shiny,
       game,
       dex_type: dexType
@@ -84,7 +85,7 @@ export function Register () {
       await dispatch(createUser(payload));
       ReactGA.event({ action: 'register', category: 'Session' });
       dispatch(setNotification(true));
-      history.push(`/u/${username}/${slug(title, { lower: true })}`);
+      history.push(`/u/${username}/${payload.slug}`);
     } catch (err) {
       setError(err.message);
       window.scrollTo({ top: 0 });


### PR DESCRIPTION
### what

pass the slug that's generated on the frontend to the backend so that the backend doesn't need to deal with slug generation logic anymore