### PR TITLE
fix(account): only pass through the password if it's being edited

### DIFF
--- a/app/components/account.jsx
+++ b/app/components/account.jsx
@@ -58,8 +58,8 @@ export function Account () {
     const payload = {
       username: session.username,
       payload: {
-        password,
-        password_confirm: passwordConfirm,
+        password: isEditingPassword ? password : undefined,
+        password_confirm: isEditingPassword ? passwordConfirm : undefined,
         friend_code_3ds: friendCode3ds,
         friend_code_switch: friendCodeSwitch
       }


### PR DESCRIPTION
### what

only pass through the password if it's being edited. otherwise, send undefined. normally, we treat the empty string as wanting to clear it out. but we never want to do that for the password, so passing the empty string is a bit weird.